### PR TITLE
Filter out peripherals with no registers

### DIFF
--- a/src/svd/chip.rs
+++ b/src/svd/chip.rs
@@ -24,6 +24,7 @@ pub fn generate(c: &chip::Chip) -> crate::Result<xmltree::Element> {
     peripherals.children = c
         .peripherals
         .values()
+        .filter(has_registers)
         .map(svd::peripheral::generate)
         .collect::<Result<Vec<_>, _>>()?;
 
@@ -32,4 +33,12 @@ pub fn generate(c: &chip::Chip) -> crate::Result<xmltree::Element> {
     el.children.push(peripherals);
 
     Ok(el)
+}
+
+fn has_registers(peripheral: &&chip::Peripheral) -> bool {
+    let regs = !peripheral.registers.is_empty();
+    if !regs {
+        log::warn!("No registers found for peripheral {:?}", peripheral.name);
+    }
+    regs
 }


### PR DESCRIPTION
This fixes the parsing error I had for the atmega328pb atdf file.

Closes: #7 