### PR TITLE
Fall back to caption from module if instance caption is missing

### DIFF
--- a/src/atdf/peripheral.rs
+++ b/src/atdf/peripheral.rs
@@ -53,7 +53,7 @@ pub fn parse_list(
 
             peripherals.push(chip::Peripheral {
                 name: instance.attr("name")?.clone(),
-                description: instance.attr("caption").ok().cloned(),
+                description: instance.attr("caption").or(module.attr("caption")).ok().cloned(),
                 registers,
             })
         }


### PR DESCRIPTION
This should solve https://github.com/Rahix/atdf2svd/issues/5, s.t. on a missing caption in the `<instance ...>` element, the caption of the parent `<module ...>` is used.

Signed-off-by: trembel <silvano.cortesi@hotmail.com>