### PR TITLE
Clarifying naming of interrupt vectors on new AVR MCUs

### DIFF
--- a/src/atdf/interrupt.rs
+++ b/src/atdf/interrupt.rs
@@ -5,7 +5,12 @@ use crate::ElementExt;
 pub fn parse(interrupt: &xmltree::Element) -> crate::Result<chip::Interrupt> {
     interrupt.check_name("interrupt")?;
 
-    let name = interrupt.attr("name")?.clone();
+    let name = {
+        let inst_name = interrupt.attr("name")?;
+        interrupt
+            .attr("module-instance")
+            .map_or_else(|_| inst_name.clone(), |s| format!("{}_{}", s, inst_name))
+    };
     let index = util::parse_int(interrupt.attr("index")?)?;
     let description = interrupt
         .attributes


### PR DESCRIPTION
This solves #16. 
The commit checks if `module-instance` exists, and if yes, it appends `name` to module-instance, if not, name stays `name`.
On the new AVR series, its even a bug fix, since else multiple interrupts would have the same name.

Signed-off-by: trembel <silvano.cortesi@hotmail.com>