### PR TITLE
Use bit size instead of byte size when parsing bitmasks.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -18,7 +18,7 @@ pub fn parse_mask(s: &str) -> crate::Result<Option<((usize, usize), bool)>> {
         return Ok(None);
     }
 
-    let bits_set = (0..mem::size_of::<usize>()).filter(|i| (mask & (1 << *i)) > 0);
+    let bits_set = (0..mem::size_of::<usize>()*8).filter(|i| (mask & (1 << *i)) > 0);
     let range = (bits_set.clone().min().unwrap(), bits_set.max().unwrap());
 
     let range_bitmask = ((1 << (range.1 - range.0 + 1)) - 1) << range.0;


### PR DESCRIPTION
It uses sizeof usize but that is in bytes. We need the size in bits. The bug
appeared when parsing the 32bit LOCK bit register. For smaller sizes the old
behaviour worked because `sizeof::<usize> == 8` on most systems.