### PR TITLE
Do not read `ocd-rw` for register access mode, but read `rw`

### DIFF
--- a/src/atdf/register.rs
+++ b/src/atdf/register.rs
@@ -17,14 +17,13 @@ pub fn parse(
         .and_then(|d| if !d.is_empty() { Some(d) } else { None })
         .cloned();
 
-    let access = if let Some(access) = el.attributes.get("ocd-rw") {
+    let access = if let Some(access) = el.attributes.get("rw") {
         match access.as_ref() {
+            "" => chip::AccessMode::NoAccess,
             "R" => chip::AccessMode::ReadOnly,
-            "" => {
-                log::warn!("empty access-mode on {}", el.debug());
-                chip::AccessMode::ReadWrite
-            }
-            _ => panic!("unknown access mode {:?}", access),
+            "W" => chip::AccessMode::WriteOnly,
+            "RW" => chip::AccessMode::ReadWrite,
+            _ => chip::AccessMode::ReadWrite
         }
     } else {
         chip::AccessMode::ReadWrite

--- a/src/chip.rs
+++ b/src/chip.rs
@@ -34,6 +34,7 @@ pub struct Interrupt {
 
 #[derive(Debug, Clone, Copy)]
 pub enum AccessMode {
+    NoAccess,
     ReadOnly,
     WriteOnly,
     ReadWrite,

--- a/src/svd/restriction.rs
+++ b/src/svd/restriction.rs
@@ -72,7 +72,8 @@ pub fn generate_access(a: chip::AccessMode) -> crate::Result<Option<xmltree::Ele
     Ok(match a {
         chip::AccessMode::ReadOnly => Some("read-only"),
         chip::AccessMode::WriteOnly => Some("write-only"),
-        chip::AccessMode::ReadWrite => None,
+        chip::AccessMode::ReadWrite => Some("read-write"),
+        chip::AccessMode::NoAccess => None
     }
     .map(|m| xmltree::Element::new_with_text("access", m)))
 }


### PR DESCRIPTION
Elements without a rw attribute is RW.

SVD Access does not have a 'none' access, which can be described
with and empty rw attribute in atdf. For now, pass it down as None.

This fixes #23