### PR TITLE
Continue generation if interrupts can't be generated

### DIFF
--- a/src/svd/chip.rs
+++ b/src/svd/chip.rs
@@ -45,7 +45,9 @@ pub fn generate(c: &chip::Chip) -> crate::Result<xmltree::Element> {
         .filter(has_registers)
         .map(svd::peripheral::generate)
         .collect::<Result<Vec<_>, _>>()?;
-    svd::interrupt::generate(&mut peripherals, c)?;
+    if svd::interrupt::generate(&mut peripherals, c).is_err() {
+        log::warn!("Could not generate CPU interrupts")
+    }
     el.children.push(peripherals);
 
     Ok(el)


### PR DESCRIPTION
Cortex-A microprocessors don't have a standard interrupt controller like the NVIC for Cortex-M processors. This patch makes it ignore errors in the generation of interrupts and emits a warning if there's an error.