### PR TITLE
Add patch to remove prefixes from register names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ pub mod util;
 pub use elementext::ElementExt;
 pub use error::{DisplayError, Error, Result};
 pub use gumdrop::Options;
+use std::collections::HashSet;
+use std::iter::FromIterator;
 
 #[derive(Debug, Options)]
 /// A tool to convert AVR chip description files (.atdf) to SVD.
@@ -22,6 +24,10 @@ struct Atdf2SvdOptions {
     /// [optional] Path where to save the SVD file
     #[options(free)]
     svd_path: Option<std::path::PathBuf>,
+
+    /// List of patches to apply.
+    #[options(long = "auto-patches")]
+    auto_patches: Vec<String>,
 
     #[options(short = "d", long = "debug")]
     debug: bool,
@@ -67,7 +73,8 @@ fn main() {
         Box::new(std::io::stdout())
     };
 
-    let chip = atdf::parse(atdf_file).unwrap_or_else(|e| cli::exit_with_error(e));
+    let patches = HashSet::from_iter(args.auto_patches.iter().cloned());
+    let chip = atdf::parse(atdf_file, &patches).unwrap_or_else(|e| cli::exit_with_error(e));
 
     if args.debug {
         eprintln!("{:#?}", chip);


### PR DESCRIPTION
This is just a proof of concept, remove prefixes from register names on each peripheral.

For example on ADC when there is a list of registers named `ADC_<name>` it will remove the `ADC_` part leaving `<name>`.

I've thought of using the peripheral name as a guess but on the ATDF file I'm converting the FLEXCOM peripherals have registers named `FLEX_<>` so it wasn't possible, so I opted to find the longest matching common prefix on the registers name that ended with an underscore.

This could be under a command line flag if it causes problems on other ATDF files, for example it can also mistakenly remove prefixes that should probably not be removed (e.g.: a set of registers that are `CH_CR`, `CH_SR`, etc.), haven't found something like that though.