### PR TITLE
Ensure we don't generate empty enumerated values

### DIFF
--- a/src/atdf/field.rs
+++ b/src/atdf/field.rs
@@ -43,7 +43,12 @@ pub fn parse(
         if values.len() != filtered_values.len() {
             log::warn!("Invalid enumerated values dropped for field {}", name);
         }
-        chip::ValueRestriction::Enumerated(filtered_values)
+        if !filtered_values.is_empty() {
+            chip::ValueRestriction::Enumerated(filtered_values)
+        } else {
+            log::warn!("Empty enumerated values for field {}", name);
+            chip::ValueRestriction::Unsafe
+        }
     } else if unsafe_range {
         chip::ValueRestriction::Unsafe
     } else {


### PR DESCRIPTION
Make sure we never generate `ValueRestriction::Enumerated` for an empty list of enumerated values.  This will become important when switching to svd-rs as it will refuse accepting such value restrictions.

So far, this situation was only observed for fields where we filter out invalid enumerated values.  But the check will also cover hypothetical ATDF files which have an empty list of enumerated values for some field.

Fixes: 62e5b6051951 ("Drop invalid enumerated values with a warning") from #14