### PR TITLE
Emit `alternateGroup` element in SVD for registers with multiple modes

### DIFF
--- a/src/atdf/peripheral.rs
+++ b/src/atdf/peripheral.rs
@@ -37,7 +37,15 @@ pub fn parse_list(
                 }
             }
 
-            let registers = registers.into_iter().map(|r| (r.name.clone(), r)).collect();
+            let registers = registers.into_iter().map(|r|
+                (
+                    match r.mode {
+                        Some(ref mode) => format!("{mode}_{}", r.name),
+                        _ => r.name.clone(),
+                    },
+                    r
+                )
+            ).collect();
 
             peripherals.push(chip::Peripheral {
                 name: instance.attr("name")?.clone(),

--- a/src/atdf/register.rs
+++ b/src/atdf/register.rs
@@ -17,6 +17,12 @@ pub fn parse(
         .and_then(|d| if !d.is_empty() { Some(d) } else { None })
         .cloned();
 
+    let mode = el
+        .attributes
+        .get("modes")
+        .and_then(|d| if !d.is_empty() { Some(d) } else { None })
+        .cloned();
+
     let access = if let Some(access) = el.attributes.get("rw") {
         match access.as_ref() {
             "" => chip::AccessMode::NoAccess,
@@ -40,6 +46,7 @@ pub fn parse(
     Ok(chip::Register {
         name,
         description,
+        mode,
         address: util::parse_int(el.attr("offset")?)? + offset,
         size: util::parse_int(el.attr("size")?)?,
         access,

--- a/src/chip.rs
+++ b/src/chip.rs
@@ -56,6 +56,7 @@ pub enum ValueRestriction {
 pub struct Register {
     pub name: String,
     pub description: Option<String>,
+    pub mode: Option<String>,
     pub address: usize,
     pub size: usize,
     pub access: AccessMode,

--- a/src/svd/register.rs
+++ b/src/svd/register.rs
@@ -18,7 +18,8 @@ pub fn generate(r: &chip::Register, base: u32) -> crate::Result<svd_rs::Register
             None
         })
         .access(generate_access(r.access))
-        .write_constraint(write_constraint);
+        .write_constraint(write_constraint)
+        .alternate_group(r.mode.clone());
 
     let mut fields = r.fields.values().collect::<Vec<_>>();
     fields.sort_by(|a, b| a.range.0.cmp(&b.range.0));


### PR DESCRIPTION
This patch adds the capability to emit an `alternateGroup` element in the resulting SVD when a register of a peripheral has multiple modes. This is handy for the modern timer peripherals in the atxmegas and new attinys where a timer can be either set to 16 bit single mode or you can split it into two independent 8 bit timers.

The resulting registers are prefixed with the mode already by `svd2rust` as of version v0.18.0. For example in an attiny817 for peripheral TCA0 there will be `single_ctrl{a,b,c}` and `split_ctrl{a,b,c}` registers.

This should fix https://github.com/Rahix/atdf2svd/issues/4