### PR TITLE
Introduce a default-enabled `cli` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,21 @@ on:
   pull_request:
 
 jobs:
+  build:
+    name: Build and run atdf2svd CLI tool
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo run -- tests/atmega328p.atdf /dev/null
+
   test:
     name: Run atdf2svd regression tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: cargo test
+      - run: cargo test --no-default-features
 
   rustfmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
 name = "atdf2svd"
 version = "0.5.0"
 dependencies = [
+ "cfg-if",
  "colored",
  "env_logger",
  "git-version",
@@ -75,6 +76,12 @@ dependencies = [
  "svd-rs",
  "xmltree 0.10.3",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "colorchoice"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,24 @@ exclude = [
     ".github/",
 ]
 
+[[bin]]
+name = "atdf2svd"
+required-features = ["cli"]
+
+[features]
+cli = ["dep:colored", "dep:env_logger", "dep:gumdrop", "dep:git-version"]
+default = ["cli"]
+
 [dependencies]
 xmltree = "0.10.3"
-colored = "2.0.0"
+colored = { version = "2.0.0", optional = true }
 log = "0.4.22"
-env_logger = "0.11.5"
-gumdrop = "0.8.1"
-git-version = "0.3.5"
+env_logger = { version = "0.11.5", optional = true }
+gumdrop = { version = "0.8.1", optional = true }
+git-version = { version = "0.3.5", optional = true }
 svd-rs = "0.14.1"
 svd-encoder = "0.14.2"
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 insta = { version = "1.41.1", features = ["yaml"] }

--- a/src/atdf/error.rs
+++ b/src/atdf/error.rs
@@ -1,15 +1,23 @@
 use crate::ElementExt;
-use colored::Colorize;
 
 pub struct UnsupportedError(String, String);
 
 impl crate::DisplayError for UnsupportedError {
     fn format(&self, w: &mut dyn std::io::Write) -> std::io::Result<()> {
+        let maybe_styled_element = {
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "cli")] {
+                    use colored::Colorize;
+                    self.1.dimmed()
+                } else {
+                    &self.1
+                }
+            }
+        };
         write!(
             w,
             "{} is unsupported in element\n    {}",
-            self.0,
-            self.1.dimmed()
+            self.0, maybe_styled_element,
         )
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,9 +34,3 @@ pub fn exit_with_error(e: crate::Error) -> ! {
     writeln!(stderr).unwrap();
     std::process::exit(1);
 }
-
-pub fn panic_with_error(e: crate::Error) -> ! {
-    let mut message: Vec<u8> = "Error: ".into();
-    e.format(&mut message).unwrap();
-    panic!("{}", String::from_utf8_lossy(&message));
-}

--- a/src/elementext.rs
+++ b/src/elementext.rs
@@ -112,17 +112,25 @@ impl ElementExt for xmltree::Element {
 
 pub mod error {
     use super::ElementExt;
-    use colored::Colorize;
 
     pub struct MissingAttribute(String, String);
 
     impl crate::DisplayError for MissingAttribute {
         fn format(&self, w: &mut dyn std::io::Write) -> std::io::Result<()> {
+            let maybe_styled_element = {
+                cfg_if::cfg_if! {
+                    if #[cfg(feature = "cli")] {
+                        use colored::Colorize;
+                        self.1.dimmed()
+                    } else {
+                        &self.1
+                    }
+                }
+            };
             write!(
                 w,
                 "Missing attribute {:?} on\n   {}",
-                self.0,
-                self.1.dimmed()
+                self.0, maybe_styled_element,
             )
         }
     }
@@ -137,7 +145,21 @@ pub mod error {
 
     impl crate::DisplayError for MissingElement {
         fn format(&self, w: &mut dyn std::io::Write) -> std::io::Result<()> {
-            write!(w, "Missing child {:?} in\n   {}", self.0, self.1.dimmed())
+            let maybe_styled_element = {
+                cfg_if::cfg_if! {
+                    if #[cfg(feature = "cli")] {
+                        use colored::Colorize;
+                        self.1.dimmed()
+                    } else {
+                        &self.1
+                    }
+                }
+            };
+            write!(
+                w,
+                "Missing child {:?} in\n   {}",
+                self.0, maybe_styled_element
+            )
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,11 @@
 pub trait DisplayError {
     fn format(&self, w: &mut dyn std::io::Write) -> std::io::Result<()>;
+
+    fn into_panic(&self) -> ! {
+        let mut message: Vec<u8> = "Error: ".into();
+        self.format(&mut message).unwrap();
+        panic!("{}", String::from_utf8_lossy(&message));
+    }
 }
 
 pub type Error = Box<dyn DisplayError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,8 @@ pub fn run(args: Atdf2SvdOptions) {
 
 pub fn run_test(atdf: &mut dyn std::io::Read, auto_patches: Vec<&str>) -> String {
     let patches = HashSet::from_iter(auto_patches.iter().map(|s| s.to_string()));
-    let chip = atdf::parse(atdf, &patches).unwrap_or_else(|e| cli::panic_with_error(e));
+    let chip = atdf::parse(atdf, &patches).unwrap_or_else(|e| e.into_panic());
     let mut output = Vec::new();
-    svd::generate(&chip, &mut output).unwrap_or_else(|e| cli::panic_with_error(e));
+    svd::generate(&chip, &mut output).unwrap_or_else(|e| e.into_panic());
     String::from_utf8(output).unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 pub mod error;
+#[cfg(feature = "cli")]
 pub mod cli;
 
 pub mod atdf;
@@ -10,10 +11,12 @@ pub mod util;
 
 pub use elementext::ElementExt;
 pub use error::{DisplayError, Error, Result};
+#[cfg(feature = "cli")]
 pub use gumdrop::Options;
 use std::collections::HashSet;
 use std::iter::FromIterator;
 
+#[cfg(feature = "cli")]
 #[derive(Debug, Options)]
 /// A tool to convert AVR chip description files (.atdf) to SVD.
 pub struct Atdf2SvdOptions {
@@ -41,6 +44,7 @@ pub struct Atdf2SvdOptions {
     version: bool,
 }
 
+#[cfg(feature = "cli")]
 pub fn run(args: Atdf2SvdOptions) {
     if args.version {
         println!(


### PR DESCRIPTION
With our biggest user, `avr-device` switching to using this crate as a library rather than a CLI tool, it's time to somewhat pivot our dependency management towards this usecase.  There is no need to pull in all the CLI frontend dependencies for library users.

Introduce a new `cli` feature for the CLI interface.  This feature is enabled by default so the tool can still be built without issue as needed.  Library-only users like `avr-device` can disable the `cli` feature to reduce the number of unnecessary dependencies.